### PR TITLE
Fix compatibility with ResourceLoader

### DIFF
--- a/src/main/java/alexiil/mods/load/coremod/BetterLoadingScreenTransformer.java
+++ b/src/main/java/alexiil/mods/load/coremod/BetterLoadingScreenTransformer.java
@@ -10,7 +10,6 @@ import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.tree.AbstractInsnNode;
 import org.objectweb.asm.tree.ClassNode;
-import org.objectweb.asm.tree.FieldNode;
 import org.objectweb.asm.tree.InsnNode;
 import org.objectweb.asm.tree.MethodInsnNode;
 import org.objectweb.asm.tree.MethodNode;
@@ -27,8 +26,6 @@ public class BetterLoadingScreenTransformer implements IClassTransformer, Opcode
                 return transformMinecraft(basicClass);
             if (name.equals("com.mumfrey.liteloader.client.api.ObjectFactoryClient"))
                 return transformObjectFactoryClient(basicClass);
-            if (name.equals("lumien.resourceloader.ResourceLoader"))
-                return transformResourceLoader(basicClass);
         }
         catch (Throwable t) {
             System.out.println("An issue occoured while transforming " + transformedName);
@@ -118,28 +115,5 @@ public class BetterLoadingScreenTransformer implements IClassTransformer, Opcode
         classNode.accept(cw);
         System.out.println("Transformed Minecraft");
         return cw.toByteArray();
-    }
-
-    private byte[] transformResourceLoader(byte[] before) {
-        ClassNode classNode = new ClassNode();
-        ClassReader reader = new ClassReader(before);
-        reader.accept(classNode, 0);
-
-        for (MethodNode m : classNode.methods) {
-            if (m.name.equals("preInit")) {
-                m.visibleAnnotations.remove(0);// Remove @Mod.EventHandler
-            }
-        }
-
-        for (FieldNode f : classNode.fields) {
-            if (f.name.equals("INSTANCE"))
-                f.visibleAnnotations.remove(0);// Remove @Mod.Instance("ResourceLoader")
-        }
-
-        ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES | ClassWriter.COMPUTE_MAXS);
-        classNode.accept(cw);
-        byte[] arr = cw.toByteArray();
-        System.out.println("Transformed ResourceLoader!");
-        return arr;
     }
 }


### PR DESCRIPTION
Remove "@Mod.EventHandler" annotation from "preInit" will prevent ResourceLoader mod pre-initial progress. This will make ResourceLoader unavailable.
In fact, I don't know what the function of this code is. It seems no use at all. BTW, after I remove this code segment, It works fine. If this code is useful and shouldn't be removed, please point out in comment. : )