### PR TITLE
make GTNH compatible [with LiteLoader] again!

### DIFF
--- a/src/main/java/alexiil/mods/load/ProgressDisplayer.java
+++ b/src/main/java/alexiil/mods/load/ProgressDisplayer.java
@@ -217,7 +217,9 @@ public class ProgressDisplayer {
             overrideForgeSplashProgress();
             hasInitRL = true;
         }
-        displayer.displayProgress(text, percent);
+        try {
+            displayer.displayProgress(text, percent);
+        } catch (Throwable t) {}
     }
 
     public static void close() throws IOException {


### PR DESCRIPTION
Without this edit GTNH v2.3.1 is crashing at loading screen after 100% load progress, when started with [LiteLoader](https://www.liteloader.com/download#stable_1710). BTW, I'm new to java so fix me if I'm wrong somewhere.
[crash-2023-03-26_22.49.48-client.txt](https://github.com/GTNewHorizons/BetterLoadingScreen/files/11131159/crash-2023-03-26_22.49.48-client.txt)