### PR TITLE
Add imgur gallery/album background support

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/alexiil/mods/load/MinecraftDisplayer.java
+++ b/src/main/java/alexiil/mods/load/MinecraftDisplayer.java
@@ -133,8 +133,9 @@ public class MinecraftDisplayer implements IDisplayer {
     private String loadingBarsColor = "fdf900";
     private float[] lbRGB = new float[] { 1, 1, 0 };
     private float loadingBarsAlpha = 0.5F;
-    private boolean useImgur = true;
-    public static String imgurGalleryLink = "https://imgur.com/gallery/Ks0TrYE";
+    private boolean useImgur = false;
+    private String imgurAppClientId = "";
+    private String imgurGalleryId = "";
 
     private boolean saltBGhasBeenRendered = false;
 
@@ -639,10 +640,15 @@ public class MinecraftDisplayer implements IDisplayer {
         salt = cfg.getBoolean("salt", "skepticism", salt, comment29);
 
         // imgur
-        String comment30 = "Set to true if you want to load images from an imgur gallery and use them as backgrounds. WIP, not working yet";
+        String comment30 = "Set to true if you want to load images from an imgur gallery and use them as backgrounds.";
         useImgur = cfg.getBoolean("useImgur", "imgur", useImgur, comment30);
-        String comment31 = "Link to the imgur gallery";
-        imgurGalleryLink = cfg.getString("imgurGalleryLink", "imgur", imgurGalleryLink, comment31);
+        imgurAppClientId = cfg.getString(
+                "imgurAppClientId",
+                "imgur",
+                imgurAppClientId,
+                "The client ID of your imgur application. Required to access the imgur api.");
+        String comment31 = "ID of the imgur gallery/album. For example: Ks0TrYE";
+        imgurGalleryId = cfg.getString("imgurGalleryId", "imgur", imgurGalleryId, comment31);
 
         // tips
         String comment32 = "Set to true if you want to display random tips. Tips are stored in a separate file";

--- a/src/main/java/alexiil/mods/load/MinecraftDisplayer.java
+++ b/src/main/java/alexiil/mods/load/MinecraftDisplayer.java
@@ -29,6 +29,7 @@ import net.minecraft.client.audio.SoundEventAccessorComposite;
 import net.minecraft.client.audio.SoundHandler;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.ScaledResolution;
+import net.minecraft.client.renderer.texture.AbstractTexture;
 import net.minecraft.client.renderer.texture.TextureManager;
 import net.minecraft.client.resources.IResourcePack;
 import net.minecraft.client.resources.LanguageManager;
@@ -41,7 +42,11 @@ import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.SharedDrawable;
 
 import alexiil.mods.load.ProgressDisplayer.IDisplayer;
-import alexiil.mods.load.json.*;
+import alexiil.mods.load.imgur.ImgurCacheManager;
+import alexiil.mods.load.json.Area;
+import alexiil.mods.load.json.EPosition;
+import alexiil.mods.load.json.EType;
+import alexiil.mods.load.json.ImageRender;
 import cpw.mods.fml.client.FMLFileResourcePack;
 import cpw.mods.fml.client.FMLFolderResourcePack;
 import cpw.mods.fml.client.SplashProgress;
@@ -134,8 +139,6 @@ public class MinecraftDisplayer implements IDisplayer {
     private float[] lbRGB = new float[] { 1, 1, 0 };
     private float loadingBarsAlpha = 0.5F;
     private boolean useImgur = false;
-    private String imgurAppClientId = "";
-    private String imgurGalleryId = "";
 
     private boolean saltBGhasBeenRendered = false;
 
@@ -149,6 +152,8 @@ public class MinecraftDisplayer implements IDisplayer {
     public static volatile long blendStartMillis = 0;
     private static String newBlendImage = "none";
     private static int nonStaticElementsToGo;
+
+    private ImgurCacheManager imgurCacheManager = null;
 
     private ScheduledExecutorService backgroundExec = null;
     private boolean scheduledTipExecSet = false;
@@ -642,13 +647,6 @@ public class MinecraftDisplayer implements IDisplayer {
         // imgur
         String comment30 = "Set to true if you want to load images from an imgur gallery and use them as backgrounds.";
         useImgur = cfg.getBoolean("useImgur", "imgur", useImgur, comment30);
-        imgurAppClientId = cfg.getString(
-                "imgurAppClientId",
-                "imgur",
-                imgurAppClientId,
-                "The client ID of your imgur application. Required to access the imgur api.");
-        String comment31 = "ID of the imgur gallery/album. For example: Ks0TrYE";
-        imgurGalleryId = cfg.getString("imgurGalleryId", "imgur", imgurGalleryId, comment31);
 
         // tips
         String comment32 = "Set to true if you want to display random tips. Tips are stored in a separate file";
@@ -732,6 +730,22 @@ public class MinecraftDisplayer implements IDisplayer {
                         }
                     }
                 }, changeFrequency, changeFrequency, TimeUnit.SECONDS);
+
+                if (useImgur) {
+                    imgurCacheManager = new ImgurCacheManager();
+                    imgurCacheManager.loadConfig(cfg);
+
+                    List<String> imgurBackgrounds = new ArrayList<>();
+                    imgurCacheManager.setupImgurGallery(res -> {
+                        // Override the default background with the first image we get, otherwise the image will only
+                        // be visible after the first blend occurs
+                        if (imgurBackgrounds.isEmpty()) background = res.toString();
+
+                        // Progressively add each image to the list of random backgrounds
+                        imgurBackgrounds.add(res.toString());
+                        randomBackgroundArray = imgurBackgrounds.toArray(new String[0]);
+                    });
+                }
             }
         }
 
@@ -1338,8 +1352,7 @@ public class MinecraftDisplayer implements IDisplayer {
                     }
 
                     GL11.glColor4f(render.getRed(), render.getGreen(), render.getBlue(), blendAlpha);
-                    ResourceLocation res = new ResourceLocation(render.resourceLocation);
-                    textureManager.bindTexture(res);
+                    bindTexture(render.resourceLocation);
                     drawRect(
                             startX,
                             startY,
@@ -1357,8 +1370,7 @@ public class MinecraftDisplayer implements IDisplayer {
                             new Area(0, 0, 256, 256),
                             new Area(0, 0, 0, 0));
                     GL11.glColor4f(render2.getRed(), render2.getGreen(), render2.getBlue(), 1.f - blendAlpha);
-                    ResourceLocation res2 = new ResourceLocation(render2.resourceLocation);
-                    textureManager.bindTexture(res2);
+                    bindTexture(render2.resourceLocation);
                     drawRect(
                             startX,
                             startY,
@@ -1371,8 +1383,7 @@ public class MinecraftDisplayer implements IDisplayer {
                     break;
                 } else {
                     GL11.glColor4f(render.getRed(), render.getGreen(), render.getBlue(), 1F);
-                    ResourceLocation res = new ResourceLocation(render.resourceLocation);
-                    textureManager.bindTexture(res);
+                    bindTexture(render.resourceLocation);
                     drawRect(
                             startX,
                             startY,
@@ -1390,6 +1401,23 @@ public class MinecraftDisplayer implements IDisplayer {
             case CLEAR_COLOUR: // Ignore this, as its set elsewhere
                 break;
         }
+    }
+
+    private void bindTexture(String resourceLocation) {
+        ResourceLocation res = new ResourceLocation(resourceLocation);
+
+        // We cannot go through the default texture loader, because it can't load from the file system
+        AbstractTexture texture = imgurCacheManager != null ? imgurCacheManager.getCachedTexture(res) : null;
+        if (texture != null) {
+            // Add the texture to TextureManager's cache to disable the loading logic in bindTexture
+            try {
+                textureManager.loadTexture(res, texture);
+            } catch (Exception e) {
+                BetterLoadingScreen.log.error("Failed to load imgur texture: " + res.getResourcePath(), e);
+            }
+        }
+
+        textureManager.bindTexture(res);
     }
 
     public void drawString(FontRenderer font, String text, int x, int y, int colour) {
@@ -1497,5 +1525,10 @@ public class MinecraftDisplayer implements IDisplayer {
             backgroundExec.shutdown();
         }
         getOnlyList().remove(myPack);
+
+        if (imgurCacheManager != null) {
+            imgurCacheManager.cleanUp();
+            imgurCacheManager = null;
+        }
     }
 }

--- a/src/main/java/alexiil/mods/load/imgur/ImgurCacheManager.java
+++ b/src/main/java/alexiil/mods/load/imgur/ImgurCacheManager.java
@@ -1,0 +1,188 @@
+package alexiil.mods.load.imgur;
+
+import java.awt.image.BufferedImage;
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.imageio.ImageIO;
+
+import net.minecraft.client.renderer.texture.AbstractTexture;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.common.config.Configuration;
+
+import alexiil.mods.load.BetterLoadingScreen;
+
+public class ImgurCacheManager {
+
+    private static final String IMGUR_CACHE_DIR = "bls-imgur-cache";
+
+    private final Map<String, AbstractTexture> textureCache = new ConcurrentHashMap<>();
+
+    private String appClientId;
+    private String galleryId;
+    private int requestTimeout;
+
+    private volatile boolean cancelSetup;
+
+    public void loadConfig(Configuration config) {
+        appClientId = config.getString(
+                "imgurAppClientId",
+                "imgur",
+                "",
+                "The client ID of your imgur application. Required to access the imgur api.");
+        galleryId = config
+                .getString("imgurGalleryId", "imgur", "", "ID of the imgur gallery/album. For example: Ks0TrYE");
+        requestTimeout = config.getInt(
+                "imgurRequestTimeout",
+                "imgur",
+                5000,
+                100,
+                Integer.MAX_VALUE,
+                "Request timeout (ms) for imgur requests");
+    }
+
+    public AbstractTexture getCachedTexture(ResourceLocation location) {
+        if (!location.getResourceDomain().equals(IMGUR_CACHE_DIR)) return null;
+
+        return textureCache.get(location.getResourcePath());
+    }
+
+    public void cleanUp() {
+        textureCache.values().forEach(AbstractTexture::deleteGlTexture);
+        textureCache.clear();
+
+        cancelSetup = true;
+    }
+
+    public void setupImgurGallery(Consumer<ResourceLocation> textureLocationConsumer) {
+        Path cacheFolder = Paths.get(IMGUR_CACHE_DIR);
+        if (Files.notExists(cacheFolder)) {
+            try {
+                Files.createDirectory(cacheFolder);
+            } catch (IOException e) {
+                BetterLoadingScreen.log.error("Error while creating imgur cache directory", e);
+                return;
+            }
+        }
+
+        List<String> cachedImageIDs = getCachedImageIDs();
+        if (cachedImageIDs == null) return;
+
+        // Load any image that is already cached. This avoids waiting for the imgur api call to finish to get something
+        // rendering
+        loadAnyImageFromDisk(cachedImageIDs, textureLocationConsumer);
+
+        CompletableFuture.runAsync(() -> {
+            try (ImgurClient client = new ImgurClient(appClientId, requestTimeout)) {
+                client.fetchGalleryImageIDs(galleryId, true).stream().parallel().forEach(imageID -> {
+                    // This will leave behind cached images that are no longer in the gallery
+                    synchronized (cachedImageIDs) {
+                        cachedImageIDs.remove(imageID);
+                    }
+
+                    if (cancelSetup) return;
+
+                    // Should only be the image that might have been loaded in loadAnyImageFromDisk()
+                    if (textureCache.containsKey(imageID)) return;
+
+                    Path imageFile = getCachedImagePath(imageID);
+
+                    try {
+                        if (Files.exists(getCachedImagePath(imageID))) {
+                            // Read from disk
+                            readAndCacheImageFromStream(
+                                    imageID,
+                                    new BufferedInputStream(Files.newInputStream(imageFile), 1024 * 1024),
+                                    false);
+                        } else {
+                            readAndCacheImageFromStream(
+                                    imageID,
+                                    new ByteArrayInputStream(client.fetchImage(imageID)),
+                                    true);
+                        }
+                    } catch (IOException e) {
+                        BetterLoadingScreen.log.error("Error while loading imgur image", e);
+                        return;
+                    }
+
+                    synchronized (textureLocationConsumer) {
+                        textureLocationConsumer.accept(new ResourceLocation(IMGUR_CACHE_DIR, imageID));
+                    }
+                });
+            } catch (Exception e) {
+                BetterLoadingScreen.log.error("Error while fetching imgur gallery", e);
+            }
+        }).thenRunAsync(() -> {
+            // Delete cached images that are no longer in the gallery
+            try {
+                for (String id : cachedImageIDs) {
+                    Files.deleteIfExists(getCachedImagePath(id));
+                }
+            } catch (IOException e) {
+                BetterLoadingScreen.log.error("Error while deleting unused cached imgur images", e);
+            }
+        });
+    }
+
+    private void loadAnyImageFromDisk(List<String> cachedImageIDs, Consumer<ResourceLocation> textureLocationConsumer) {
+        if (cachedImageIDs.isEmpty()) return;
+
+        String imageID = cachedImageIDs.get(ThreadLocalRandom.current().nextInt(cachedImageIDs.size()));
+        try {
+            readAndCacheImageFromDisk(imageID);
+        } catch (IOException e) {
+            BetterLoadingScreen.log.error("Error while loading first cached imgur image", e);
+            return;
+        }
+
+        synchronized (textureLocationConsumer) {
+            textureLocationConsumer.accept(new ResourceLocation(IMGUR_CACHE_DIR, imageID));
+        }
+    }
+
+    private void readAndCacheImageFromStream(String imageID, InputStream imageStream, boolean saveToDisk)
+            throws IOException {
+        BufferedImage image = ImageIO.read(imageStream);
+        textureCache.put(imageID, new LateInitDynamicTexture(image, image.getWidth(), image.getHeight()));
+
+        if (saveToDisk && Files.notExists(getCachedImagePath(imageID))) writeImageToCache(imageID, image);
+    }
+
+    private void readAndCacheImageFromDisk(String imageID) throws IOException {
+        readAndCacheImageFromStream(
+                imageID,
+                new BufferedInputStream(Files.newInputStream(getCachedImagePath(imageID)), 1024 * 1024),
+                false);
+    }
+
+    private void writeImageToCache(String imageID, BufferedImage image) throws IOException {
+        ImageIO.write(
+                image,
+                "png",
+                new BufferedOutputStream(Files.newOutputStream(getCachedImagePath(imageID)), 1024 * 1024));
+    }
+
+    private static Path getCachedImagePath(String imageID) {
+        return Paths.get(IMGUR_CACHE_DIR).resolve(imageID + ".png");
+    }
+
+    private List<String> getCachedImageIDs() {
+        try (Stream<Path> cacheFolderStream = Files.list(Paths.get(IMGUR_CACHE_DIR))) {
+            return cacheFolderStream.map(path -> path.getFileName().toString().replace(".png", ""))
+                    .collect(Collectors.toList());
+        } catch (IOException e) {
+            BetterLoadingScreen.log.error("Error while iterating imgur cache folder", e);
+            return null;
+        }
+    }
+}

--- a/src/main/java/alexiil/mods/load/imgur/LateInitDynamicTexture.java
+++ b/src/main/java/alexiil/mods/load/imgur/LateInitDynamicTexture.java
@@ -1,0 +1,32 @@
+package alexiil.mods.load.imgur;
+
+import java.awt.image.BufferedImage;
+
+import net.minecraft.client.renderer.texture.AbstractTexture;
+import net.minecraft.client.renderer.texture.TextureUtil;
+import net.minecraft.client.resources.IResourceManager;
+
+/**
+ * This class is basically like {@link net.minecraft.client.renderer.texture.DynamicTexture}, but it doesn't allocate
+ * and upload the texture until {@link #loadTexture(IResourceManager)} is called.
+ */
+public class LateInitDynamicTexture extends AbstractTexture {
+
+    private final int[] dynamicTextureData;
+    private final int width;
+    private final int height;
+
+    public LateInitDynamicTexture(BufferedImage image, int width, int height) {
+        this.width = width;
+        this.height = height;
+        this.dynamicTextureData = new int[width * height];
+        image.getRGB(0, 0, width, height, this.dynamicTextureData, 0, width);
+    }
+
+    public void loadTexture(IResourceManager rs) {
+        if (this.glTextureId != -1) return;
+
+        TextureUtil.allocateTexture(this.getGlTextureId(), this.width, this.height);
+        TextureUtil.uploadTexture(this.getGlTextureId(), this.dynamicTextureData, this.width, this.height);
+    }
+}

--- a/src/main/java/alexiil/mods/load/json/ImgurClient.java
+++ b/src/main/java/alexiil/mods/load/json/ImgurClient.java
@@ -1,0 +1,79 @@
+package alexiil.mods.load.json;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.message.BasicHeader;
+
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonParseException;
+
+public class ImgurClient implements AutoCloseable {
+
+    private final CloseableHttpClient client;
+
+    public ImgurClient(String clientId) {
+        this.client = HttpClients.custom()
+                .setDefaultHeaders(Collections.singletonList(new BasicHeader("Authorization", "Client-ID " + clientId)))
+                .build();
+    }
+
+    public List<String> fetchGalleryImageIDs(String galleryId, boolean ignoreAds)
+            throws IOException, JsonParseException {
+        try (CloseableHttpResponse response = client
+                .execute(new HttpGet("https://api.imgur.com/3/album/" + galleryId))) {
+            if (response.getStatusLine().getStatusCode() != 200)
+                throw new IOException("Failed to fetch gallery image IDs. Server returned " + response.getStatusLine());
+
+            String json = new String(IOUtils.toByteArray(response.getEntity().getContent()), StandardCharsets.UTF_8);
+            GalleryResponse galleryResponse = new GsonBuilder().create().fromJson(json, GalleryResponse.class);
+
+            if (galleryResponse.data == null || galleryResponse.data.images == null)
+                throw new IOException("Server returned unexpected json format: " + json);
+
+            return galleryResponse.data.images.stream().filter(image -> !ignoreAds || !image.is_ad)
+                    .map(image -> image.id).collect(Collectors.toList());
+        }
+    }
+
+    public byte[] fetchImage(String imageId) {
+        // Note that Imgur allows requesting JPG images as PNGs, although the returned image will still be a JPG.
+        try (CloseableHttpResponse response = client.execute(new HttpGet("https://i.imgur.com/" + imageId + ".png"))) {
+            if (response.getStatusLine().getStatusCode() != 200)
+                throw new IOException("Failed to fetch image. Server returned " + response.getStatusLine());
+
+            return IOUtils.toByteArray(response.getEntity().getContent());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        this.client.close();
+    }
+
+    private static class GalleryResponse {
+
+        public GalleryData data;
+
+        private static class GalleryData {
+
+            public List<GalleryImage> images;
+
+            private static class GalleryImage {
+
+                public String id;
+                public boolean is_ad;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR allows the user to specify a gallery id, which will then be used to fetch background images to be used instead of the default ones.

# Implementation
- Two new config options were added for the imgur API client id and the gallery id
- The gallery metadata is fetched once, each time the client starts up (well within rate limit)
- Images are fetched on a separate thread and then added to the `randomBackgroundArray` one by one
- Images are cached locally
- The first image (if it exists) from the cache folder is loaded synchronously to immediately display at least one image, otherwise the default `randomBackgroundArray` is used until imgur images are available

I tried to touch very little existing code to not disturb this mess of a codebase.

## Client ID
Unfortunately, the imgur API does not allow unauthorized access, therefore a client ID is required. This can be obtained by registering an application using an imgur account [here](https://api.imgur.com/oauth2/addclient). Each user will have to do this themselves. I'm not sure if this should be documented somewhere.