### PR TITLE
Fix running in a headless Swing/AWT environment

### DIFF
--- a/src/main/java/alexiil/mods/load/LoadingFrame.java
+++ b/src/main/java/alexiil/mods/load/LoadingFrame.java
@@ -2,6 +2,7 @@ package alexiil.mods.load;
 
 import java.awt.BorderLayout;
 import java.awt.Dimension;
+import java.awt.GraphicsEnvironment;
 import java.awt.Rectangle;
 import java.awt.Toolkit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -62,6 +63,9 @@ public class LoadingFrame extends JFrame {
     private ThreadIncrementer incrementer;
 
     public static void setSystemLAF() {
+        if (GraphicsEnvironment.isHeadless()) {
+            return;
+        }
         String clsName = UIManager.getSystemLookAndFeelClassName();
         try {
             UIManager.setLookAndFeel(clsName);


### PR DESCRIPTION
Check for headless status before attempting to load Swing UI themes.